### PR TITLE
Added a requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy==1.7.1
+#pyopencv>=2.0
+pillow==2.2.1
+pyttsx==1.1


### PR DESCRIPTION
 Added a requirements.txt *nix users can use pip to install deps instead of other stuff.  PyOpenCV seems to not install from pip though.  At least on OSX.

Need app guys.  If you don't mind, I might try and help tackle some bugs in my spare time.
